### PR TITLE
Set up GitLab CI with official GCC image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,9 @@
+image: gcc
+
+test:
+  script:
+    - autoreconf -i
+    - mkdir -p build
+    - ./configure --prefix=$pwd/build
+    - make
+    - make test


### PR DESCRIPTION
In this first iteration, only a single job that autoconfs, configures,
makes and makes test.

Using the official gcc image, this avoids the need for the boost
libary, because the features are present in C++14.